### PR TITLE
Update the formula to use SHA256

### DIFF
--- a/opensplice.rb
+++ b/opensplice.rb
@@ -4,7 +4,7 @@ class Opensplice < Formula
   homepage "http://www.prismtech.com/opensplice"
   url "https://github.com/osrf/opensplice/releases/download/6.4.0-0/opensplice-6.4.0-0.tar.gz"
   version "6.4.0"
-  sha1 "f562f3507d6e80e4df1ac8252ac661e6e3142879"
+  sha256 "5b1e6e6241605efb29cc980e9db0286034e1b4b92dd94e9324952b1c31213ade"
 
   depends_on "cmake" => :build
   depends_on "gawk"
@@ -22,7 +22,7 @@ class Opensplice < Formula
     root_url 'https://github.com/osrf/opensplice/releases/download/6.4.0-0'
     cellar :any
     revision 0
-    sha1 "af9b98efe3e10ad0f99b0916c2e9901b28a33edf" => :mavericks
+    sha256 "fda3a77e4a7c6655383ea0c687ed4d1b3adb2b581c8c3389863bb06e2e9177c5" => :mavericks
   end
 
   head 'https://github.com/osrf/opensplice', :using => :git


### PR DESCRIPTION
SHA1 is disabled on the latest version of Homebrew, which now recommends switching to SHA256

```sh
$ brew install opensplice
Updating Homebrew...
Error: Calling Formula.sha1 is disabled!
Use Formula.sha256 instead.
/usr/local/Homebrew/Library/Taps/osrf/homebrew-ros2/opensplice.rb:7:in `<class:Opensplice>'
Please report this to the osrf/ros2 tap!
Please report this bug:
  https://git.io/brew-troubleshooting
/usr/local/Homebrew/Library/Homebrew/utils.rb:85:in `odeprecated'
/usr/local/Homebrew/Library/Homebrew/utils.rb:93:in `odisabled'
/usr/local/Homebrew/Library/Homebrew/compat/sha1.rb:3:in `sha1'
/usr/local/Homebrew/Library/Taps/osrf/homebrew-ros2/opensplice.rb:7:in `<class:Opensplice>'
/usr/local/Homebrew/Library/Taps/osrf/homebrew-ros2/opensplice.rb:3:in `load_formula'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:25:in `module_eval'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:25:in `load_formula'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:42:in `load_formula_from_path'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:97:in `load_file'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:88:in `klass'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:84:in `get_formula'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:241:in `factory'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:406:in `find_with_priority'
/usr/local/Homebrew/Library/Homebrew/extend/ARGV.rb:45:in `block in formulae'
/usr/local/Homebrew/Library/Homebrew/extend/ARGV.rb:41:in `map'
/usr/local/Homebrew/Library/Homebrew/extend/ARGV.rb:41:in `formulae'
/usr/local/Homebrew/Library/Homebrew/cmd/install.rb:107:in `install'
/usr/local/Homebrew/Library/Homebrew/brew.rb:94:in `<main>'
```